### PR TITLE
Fixed Environment Status Check

### DIFF
--- a/.github/workflows/BuildNorm.yml
+++ b/.github/workflows/BuildNorm.yml
@@ -30,29 +30,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Add environment variables
-        run: echo status=prod > .env
-          
       - name: Build project
-        if: matrix.os == 'windows-latest'
         run: |
           pip install pyinstaller
-          pyinstaller --exclude-module tkinter -i 'media/norm_icon.ico' -n Norm_the_6_Mans_Bot --add-data '.env;.' --onefile src/bot.py
+          pyinstaller --exclude-module tkinter -i 'media/norm_icon.ico' -n Norm_the_6_Mans_Bot --onefile src/bot.py
 
-      - name: Build project
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          pip install pyinstaller
-          pyinstaller --exclude-module tkinter -i 'media/norm_icon.ico' -n Norm_the_6_Mans_Bot --add-data '.env:.' --onefile src/bot.py
-
-      - name: Upload Binary as Release Asset
+      - name: Upload Binary as Release Asset - Windows
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v2
         with:
           path: dist/Norm_the_6_Mans_Bot.exe
           name: Norm_the_6_Mans_Bot_Windows
 
-      - name: Upload Binary as Release Asset
+      - name: Upload Binary as Release Asset - Unix
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 discord.py
-python-dotenv
 flake8
 wget
 requests

--- a/src/AWSHelper.py
+++ b/src/AWSHelper.py
@@ -1,17 +1,18 @@
 import boto3
-from dotenv import load_dotenv
-from os import getenv
 import json
+from os import path
+from sys import argv
 from FilePaths import leaderboardPath, tokenPath
 
 
+s3 = None
+leaderboardFile = ""
 aws_id = ""
 aws_secret = ""
-s3 = None
 
-# the lack of .env file results in dev
-load_dotenv()
-status = getenv("status")
+# Set prod/dev status based on file extension
+_, file_extension = path.splitext(argv[0])
+status = "prod" if file_extension == ".exe" else "dev"
 leaderboardFile = "Leaderboard.json" if status == "prod" else "Test_Leaderboard.json"
 
 if (aws_id == "" or aws_secret == ""):

--- a/src/AWSHelper.py
+++ b/src/AWSHelper.py
@@ -6,7 +6,6 @@ from FilePaths import leaderboardPath, tokenPath
 
 
 s3 = None
-leaderboardFile = ""
 aws_id = ""
 aws_secret = ""
 

--- a/src/AWSHelper.py
+++ b/src/AWSHelper.py
@@ -5,9 +5,9 @@ from sys import argv
 from FilePaths import leaderboardPath, tokenPath
 
 
-s3 = None
 aws_id = ""
 aws_secret = ""
+s3 = None
 
 # Set prod/dev status based on file extension
 _, file_extension = path.splitext(argv[0])

--- a/src/bot.py
+++ b/src/bot.py
@@ -5,7 +5,6 @@ __license__ = "MIT"
 __version__ = "4.2.1"
 __maintainer__ = "Caleb Smith / Twan / Matt Wells (Tux)"
 __email__ = "caleb.benjamin9799@gmail.com"
-__status__ = "dev"
 
 
 import asyncio


### PR DESCRIPTION
The difference between `prod` and `dev` now matters as `dev` will pull the `Test_Leaderboard.json` from AWS and `prod` will pull the main `Leaderboard.json` from AWS. 

To make this determination easy and automatic, I initally tried a `.env` file in the pipeline which didn't actually work. Instead of doing that, I am now just checking the file extension. If the extension is `.exe` then we assume the status is `prod`. Any other file extension sets the status to `dev`. 

I don't really see any security concerns when it comes to the Leaderboards as you will still need the aws credentials to be able to write to the remote files, so determining based on extension should be fine even if it's a bit hacky.

*Not a release*