### PR TITLE
Sort Leaderboard by Wins

### DIFF
--- a/github_pages_files/js/main.js
+++ b/github_pages_files/js/main.js
@@ -1,45 +1,35 @@
 $(function () {
-    $.ajax({
-        type: "get",
-        url: "https://uncc-six-mans.s3.amazonaws.com/Leaderboard.json",
-        dataType: "json",
-        success: (data) => populateTable(data)
-    });
-    setScrollBar();
-    $(window).resize(setScrollBar)
-
+  $.ajax({
+    type: "get",
+    url: "https://uncc-six-mans.s3.amazonaws.com/Leaderboard.json",
+    dataType: "json",
+    success: (data) => populateTable(data),
+  });
+  setScrollBar();
+  $(window).resize(setScrollBar);
 });
 
 function populateTable(ballChasers) {
-    not_enough_matches = [];
-    let rank = 0;
-    ballChasers.forEach(ballChaser => {
-        if (ballChaser["Matches Played"] < 5) {
-            not_enough_matches.push(ballChaser["Name"]);
-        } else {
-            rank += 1;
-            $("#leaderboard-table > tbody").append(
-                `<tr>
-                    <td headers="name">${rank}</td>
-                    <td headers="name">${ballChaser["Name"]}</td>
-                    <td headers="wins">${ballChaser["Wins"]}</td>
-                    <td headers="losses">${ballChaser["Losses"]}</td>
-                    <td headers="matches-played">${ballChaser["Matches Played"]}</td>
-                    <td headers="win-perc">${parseInt(ballChaser["Win Perc"] * 100)}%</td>
-                </tr>`
-            )
-        }
-    });
-    $("#leaderboard-table > tfoot").append(
-        `<tr>
-            <td colspan="6">Players with less than 5 matches played:</td>
-        </tr>
-        <tr>
-            <td colspan="6">${not_enough_matches.join(", ")}</td>
+  not_enough_matches = [];
+  ballChasers.forEach((ballChaser, index) => {
+    $("#leaderboard-table > tbody").append(
+      `<tr>
+            <td headers="name">${index + 1}</td>
+            <td headers="name">${ballChaser["Name"]}</td>
+            <td headers="wins">${ballChaser["Wins"]}</td>
+            <td headers="losses">${ballChaser["Losses"]}</td>
+            <td headers="matches-played">${ballChaser["Matches Played"]}</td>
+            <td headers="win-perc">${parseInt(
+              ballChaser["Win Perc"] * 100
+            )}%</td>
         </tr>`
-    )
+    );
+  });
 }
 
 function setScrollBar() {
-    $("#content").css("height", window.innerHeight - $("header")[0].getBoundingClientRect().height);
+  $("#content").css(
+    "height",
+    window.innerHeight - $("header")[0].getBoundingClientRect().height
+  );
 }

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             Latest Norm Release
             <img alt="Github" src="./github_pages_files/icons/github.svg" width=25 />
           </a>
-          <p>Created by Caleb, Twan the Swan, and Tux</p>
+          <p>Created by Caleb, Twan, and Tux</p>
         </div>
       </section>
 
@@ -205,7 +205,6 @@
             </tr>
           </thead>
           <tbody></tbody>
-          <tfoot></tfoot>
         </table>
       </section>
     </main>

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -43,7 +43,7 @@ def readLeaderboard():
 
 
 def saveLeaderboard(new_leaderboard):
-    sorted_ldrbrd = sorted(new_leaderboard, key=lambda x: (x["Win Perc"], x["Wins"]), reverse=True)
+    sorted_ldrbrd = sorted(new_leaderboard, key=lambda x: (x["Wins"], x["Win Perc"]), reverse=True)
     with open(leaderboardPath, "w") as ldrbrd:
         json.dump(sorted_ldrbrd, ldrbrd)
     AWS.writeRemoteLeaderboard()
@@ -252,25 +252,16 @@ def showLeaderboard(player=None, limit=None):
         player_index = getPlayerIndex(player)
         player_data = curr_leaderboard[player_index]
 
-        if (player_data["Matches Played"] < 5):
-            return (player_data["Name"], player_data["Matches Played"])
+        if (player_index == -1):
+            return player
 
-        index = 0
-        for i, p in enumerate(curr_leaderboard):
-            if (i == player_index):
-                break
-            elif (p["Matches Played"] >= 5):
-                index += 1
-
-        return "```" + makePretty(index, player_data) + "\n```"
+        return "```" + makePretty(player_index, player_data) + "\n```"
 
     else:
         msg = "```\n"
 
-        index = 0
-        for player_data in curr_leaderboard:
-            if ((not limit or index < limit) and player_data["Matches Played"] >= 5):
-                msg += makePretty(index, player_data) + "\n"
-                index += 1
+        for i, player_data in enumerate(curr_leaderboard):
+            if (not limit or i < limit):
+                msg += makePretty(i, player_data) + "\n"
 
         return msg + "\n```"

--- a/src/bot.py
+++ b/src/bot.py
@@ -2,7 +2,7 @@ __author__ = "Caleb Smith / Twan / Matt Wells (Tux)"
 __copyright__ = "Copyright 2019, MIT License"
 __credits__ = "Caleb Smith / Twan / Matt Wells (Tux)"
 __license__ = "MIT"
-__version__ = "5.1.1"
+__version__ = "5.2.0"
 __maintainer__ = "Caleb Smith / Twan / Matt Wells (Tux)"
 __email__ = "caleb.benjamin9799@gmail.com / unavailable / mattwells878@gmail.com"
 
@@ -653,7 +653,7 @@ async def reportMatch(ctx, *arg):
     await ctx.send(embed=embed)
 
 
-@client.command(name="leaderboard", aliases=["standings", "rank", "rankings", "stonks"], pass_contex=True)
+@client.command(name="leaderboard", aliases=["lb", "standings", "rank", "rankings", "stonks"], pass_contex=True)
 async def showLeaderboard(ctx, *arg):
 
     playerMentioned: bool = len(ctx.message.mentions) == 1
@@ -665,6 +665,7 @@ async def showLeaderboard(ctx, *arg):
             player = Jason.BallChaser(str(ctx.message.mentions[0]), ctx.message.mentions[0].id)
         else:
             player = Jason.BallChaser(str(ctx.message.author), ctx.message.author.id)
+
         players_rank = Leaderboard.showLeaderboard(player)
 
         if (type(players_rank) == str):
@@ -674,9 +675,8 @@ async def showLeaderboard(ctx, *arg):
             )
         else:
             embed = ErrorEmbed(
-                title="Not Enough Matches Played",
-                desc="{0} has played {1}/5 matches needed to be"
-                " on the leaderboard.".format(players_rank[0], players_rank[1])
+                title="No Matches Played",
+                desc="{0} hasn't played any matches and won't show up on the leaderboard.".format(players_rank.mention)
             )
 
     elif (len(arg) == 0 and len(ctx.message.mentions) == 0):


### PR DESCRIPTION
Turns out Win Perc. is not the best metric for determining best performing players. The leaderboard is going to now be sorted by Wins and tie breakers are decided by Win Perc. This is to encourage playing as many games as possible. The 5 game minimum requirement has also been removed as it is no longer necessary.

Let me know if you have any questions.