### PR TITLE
TinyDb Custom Doc Id Implemenation

### DIFF
--- a/src/Commands/EasterEggs.py
+++ b/src/Commands/EasterEggs.py
@@ -4,7 +4,7 @@ from random import choice
 import Queue
 from EmbedHelper import ErrorEmbed, QueueUpdateEmbed
 
-pikaO = 1
+pikaO = 0
 
 
 def EightBall(author: Member):
@@ -43,14 +43,14 @@ def EightBall(author: Member):
 
 
 def Teams() -> str:
-    return "it goes like this:\n"
-    "A team: doesn't practice but somehow is good"
-    "\nB team: everyone hates how their teamates play but don't talk it out to resolve issues"
-    "\nC team: who?"
-    "\nD team: best team"
-    "\nE team: surprisingly solid"
-    "\nF team: how many fkn teams do we have"
-    "\nGG team: originally g team"
+    return ("it goes like this:\n"
+            "A team: doesn't practice but somehow is good"
+            "\nB team: everyone hates how their teamates play but don't talk it out to resolve issues"
+            "\nC team: who?"
+            "\nD team: best team"
+            "\nE team: surprisingly solid"
+            "\nF team: how many fkn teams do we have"
+            "\nGG team: originally g team")
 
 
 def NormQ() -> List[str or Embed]:
@@ -83,18 +83,19 @@ def NormQ() -> List[str or Embed]:
 
 
 def Duis() -> str:
-    return "Papa Duis, mor like God Duis. Don't even think about queueing up against him because he will ruin you."
-    " You think you're good?\n\nyou think you're good at RL??!?!?!?!?!?!?!?!?!?!?\nfuck no\nyou aren't good.\n"
-    "you are shit\nur fkn washed\n You don't even come close to Duis. He will absolutely ruin you without even"
-    " looking. His monitor is off 90 percent of the time, eyes closed too. Never doubt the Duis, bitch"
+    return ("Papa Duis, mor like God Duis. Don't even think about queueing up against him because he will ruin you."
+            " You think you're good?\nyou think you're good at RL??!?!?!?!?!?!?!?!?!?!?\nfuck no\nyou aren't good.\n"
+            "you are shit\nur fkn washed\n You don't even come close to Duis. He will absolutely ruin you without even"
+            " looking. His monitor is off 90 percent of the time, eyes closed too. Never doubt the Duis, bitch")
 
 
 def Zappa() -> str:
-    return "<:zappa:632813684678197268> <:zapp:632813709579911179> brainyzac more like brainyWACK amirite...that is"
-    " until you get absolutely destroyed by him in 6mans and all the self resprct you had for yourself flies out"
-    " the window. Not even sykes can beat him in a 1v1, so what makes you think you can? Do you have 2 emotes in"
-    " this server? I didnt think so idiot, so <:zappa:632813684678197268> and <:zapp:632813709579911179> outta"
-    " here cuz you're the whack one here <:zappa:632813684678197268> <:zapp:632813709579911179>"
+    return ("<:zappa:632813684678197268> <:zapp:632813709579911179> brainyzac more like brainyWACK amirite...that is"
+            " until you get absolutely destroyed by him in 6mans and all the self resprct you had for yourself flies"
+            " out the window. Not even sykes can beat him in a 1v1, so what makes you think you can? Do you have 2"
+            " emotes in this server? I didnt think so idiot, so <:zappa:632813684678197268> and"
+            " <:zapp:632813709579911179> outta here cuz you're the whack one here <:zappa:632813684678197268>"
+            " <:zapp:632813709579911179>")
 
 
 def Pika() -> str:
@@ -114,10 +115,10 @@ def Smh() -> str:
 
 
 def Twan() -> str:
-    return "<:twantheswan:540327706076905472> twantheswan is probably the greatest Rocket League (tm) player to have"
-    " ever walked the face of this planet. When he tries, no one ever beats him. If you beat him in a game, he"
-    " was letting you win just to make you feel better. ur fkn trash at rl unless u r twantheswan. sub to him on"
-    " twitch <:twantheswan:540327706076905472>"
+    return ("<:twantheswan:540327706076905472> twantheswan is probably the greatest Rocket League (tm) player to have"
+            " ever walked the face of this planet. When he tries, no one ever beats him. If you beat him in a game, he"
+            " was letting you win just to make you feel better. ur fkn trash at rl unless u r twantheswan. sub to him"
+            " on twitch <:twantheswan:540327706076905472>")
 
 
 def Sad() -> str:

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -98,16 +98,16 @@ def reportMatch(player: Member, whoWon: Team) -> str:
                 win = 0
                 loss = 1
 
-            player = leaderboard.get(where(LbKey.ID) == teamMember[MatchKey.ID])
+            player = leaderboard.get(doc_id=teamMember[MatchKey.ID])
             if (not player):
-                leaderboard.insert({
+                leaderboard.insert(Document({
                     LbKey.ID: teamMember[MatchKey.ID],
                     LbKey.NAME: teamMember[MatchKey.NAME],
                     LbKey.WINS: win,
                     LbKey.LOSSES: loss,
                     LbKey.MATCHES: 1,
                     LbKey.WIN_PERC: float(win),
-                })
+                }, doc_id=teamMember[MatchKey.ID]))
             else:
                 updated_player = {
                     LbKey.NAME: teamMember[MatchKey.NAME],
@@ -147,7 +147,7 @@ def showLeaderboard(player: Member = None, limit: int = None) -> str or List[str
         sorted_lb = sorted(leaderboard.all(), key=lambda x: (x[LbKey.WINS], x[LbKey.WIN_PERC]), reverse=True)
 
     if (player):
-        player_data = leaderboard.get(where(LbKey.ID) == player.id)
+        player_data = leaderboard.get(doc_id=player.id)
 
         if (not player_data):
             return player
@@ -185,4 +185,5 @@ def showLeaderboard(player: Member = None, limit: int = None) -> str or List[str
 
 def resetFromRemote(remoteData: dict) -> None:
     leaderboard.truncate()
-    leaderboard.insert_multiple(remoteData)
+    for p in remoteData:
+        leaderboard.insert(Document(p, doc_id=p["id"]))

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -6,6 +6,7 @@ from json import dumps
 from tinydb import where
 from tinydb.table import Document
 from typing import List
+import concurrent.futures
 
 
 sorted_lb = None
@@ -125,7 +126,9 @@ def reportMatch(player: Member, whoWon: Team) -> str:
 
     activeMatches.remove(doc_ids=[match.doc_id])
     sorted_lb = sorted(leaderboard.all(), key=lambda x: (x[LbKey.WINS], x[LbKey.WIN_PERC]), reverse=True)
-    AWS.writeRemoteLeaderboard(dumps(sorted_lb))
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        executor.submit(AWS.writeRemoteLeaderboard, dumps(sorted_lb))
 
     return ":white_check_mark: Match has been reported successfully."
 

--- a/src/TestHelper.py
+++ b/src/TestHelper.py
@@ -3,6 +3,7 @@ from Queue import clearQueue, BallChaser
 from Types import Team, MatchKey, BallChaserKey
 from datetime import datetime, timedelta
 from tinydb import where
+from tinydb.table import Document
 
 
 def fillQueue():
@@ -39,7 +40,8 @@ def fillQueue():
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
     ]
-    currQueue.insert_multiple([p.toJSON() for p in new_queue])
+    for p in new_queue:
+        currQueue.insert(Document(p.toJSON(), doc_id=p.id))
 
 
 def fillWithCaptains():
@@ -80,7 +82,8 @@ def fillWithCaptains():
             queueTime=(datetime.now() + timedelta(minutes=60))
         ),
     ]
-    currQueue.insert_multiple([p.toJSON() for p in new_queue])
+    for p in new_queue:
+        currQueue.insert(Document(p.toJSON(), doc_id=p.id))
 
 
 def flipCaptains():

--- a/src/bot.py
+++ b/src/bot.py
@@ -89,15 +89,6 @@ async def on_ready():
     print("Logged in as " + client.user.name + " version " + __version__)
 
     try:
-        AWS.readRemoteLeaderboard()
-        if (LEADERBOARD_CH_ID != -1):
-            LB_CHANNEL = client.get_channel(LEADERBOARD_CH_ID)
-            await Utils.updateLeaderboardChannel(LB_CHANNEL)  # update leaderboard channel when remote leaderboard pulls
-    except Exception as e:
-        # this should only throw an exception if the Leaderboard file does not exist or the credentials are invalid
-        print(e)
-
-    try:
         channel = client.get_channel(QUEUE_CH_IDS[0])
         await channel.send(embed=AdminEmbed(
             title="Norm Started",
@@ -105,6 +96,16 @@ async def on_ready():
         ))
     except Exception as e:
         print("! Norm does not have access to post in the queue channel.", e)
+
+    try:
+        AWS.readRemoteLeaderboard()
+        if (LEADERBOARD_CH_ID != -1):
+            LB_CHANNEL = client.get_channel(LEADERBOARD_CH_ID)
+            # update leaderboard channel when remote leaderboard pulls
+            await Utils.updateLeaderboardChannel(LB_CHANNEL)
+    except Exception as e:
+        # this should only throw an exception if the Leaderboard file does not exist or the credentials are invalid
+        print(e)
 
 
 async def stale_queue_timer():


### PR DESCRIPTION
When I first switched everything over to using TinyDb, there was no way to specify a custom doc id for entries in the tables. Since then, that feature was released. This PR uses the Discord ID of everyone to key their entry in each of the tables. This makes queries much easier and even a little quicker.

Also made `AWS.writeRemoteLeaderboard` a thread in `Leaderboard.py` that allows the function to return without having to wait for the remote leaderboard to be updated.

Also other small bug fixes I noticed.