### PR TITLE
Update NormBuild step to use Python 3.8.6

### DIFF
--- a/.github/workflows/BuildNorm.yml
+++ b/.github/workflows/BuildNorm.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [master]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build project files

--- a/.github/workflows/BuildNorm.yml
+++ b/.github/workflows/BuildNorm.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8.6
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Norm is developed using `typing` which allows us to add types to make the code more readable and easier to understand. `typing` was not fully supported until Python 3.8. Because the Github Action to build Norm was running `pyinstaller` using Python 3.7, this was causing the executable to fail during runtime. This work updates the BuildNorm step to use Python 3.8.6 to solve this issue.

Also included is `workflow_dispatch` which allows us to manually run the BuildNorm stage in the future.