### PR TITLE
Added !update to pass the author's roles

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -396,7 +396,7 @@ async def update(ctx):
         title="Checking For Updates",
         desc="Please hang tight."
     ))
-    await ctx.send(embed=Admin.update())
+    await ctx.send(embed=Admin.update(ctx.message.author.roles))
 
 
 """


### PR DESCRIPTION
v6.0.0 introduced a bug that broke the update command.
Update command was not passing the author's roles to be validated.