### PR TITLE
Fix for update embed

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -392,7 +392,7 @@ async def restart(ctx):
 
 @client.command(name="update", pass_context=True)
 async def update(ctx):
-    await ctx.send(AdminEmbed(
+    await ctx.send(embed=AdminEmbed(
         title="Checking For Updates",
         desc="Please hang tight."
     ))


### PR DESCRIPTION
Embed was incorrectly being sent as a message. Now correctly sends as an embed object.