### PR TITLE
Added fixes For Captain Validaiton and Leaderboard

### DIFF
--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -396,7 +396,7 @@ def leaderboard(author: Member, mentions: str, lbChannelId: int, *arg) -> Embed:
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed
 
-    elif (len(arg) == 0 and playerMentioned == False and not Leaderboard.emptyLeaderboard()):
+    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.countLeaderboard() >= 6):
         viewFullLb = "\nTo see the full leaderboard, visit <#{0}>.".format(lbChannelId) if (lbChannelId != -1) else ""
         embed = InfoEmbed(
             title="UNCC 6 Mans | Top 5",
@@ -405,7 +405,7 @@ def leaderboard(author: Member, mentions: str, lbChannelId: int, *arg) -> Embed:
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed
 
-    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.emptyLeaderboard()):
+    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.countLeaderboard() < 6):
         embed = ErrorEmbed(
             title="No Leaderboard!",
             desc="There are currently no leaderboard statistics!"

--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -396,22 +396,22 @@ def leaderboard(author: Member, mentions: str, lbChannelId: int, *arg) -> Embed:
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed
 
-    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.countLeaderboard() >= 6):
-        viewFullLb = "\nTo see the full leaderboard, visit <#{0}>.".format(lbChannelId) if (lbChannelId != -1) else ""
-        embed = InfoEmbed(
-            title="UNCC 6 Mans | Top 5",
-            desc=Leaderboard.showLeaderboard(limit=5) + viewFullLb
-        )
-        edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
-        return edited_embed
-
-    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.countLeaderboard() < 6):
-        embed = ErrorEmbed(
-            title="No Leaderboard!",
-            desc="There are currently no leaderboard statistics!"
-        )
-        edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
-        return edited_embed
+    elif (len(arg) == 0 and playerMentioned == False):
+        if (Leaderboard.countLeaderboard() >= 6):
+            viewFullLb = "\nTo see the full leaderboard, visit <#{0}>.".format(lbChannelId) if (lbChannelId != -1) else "" # noqa
+            embed = InfoEmbed(
+                title="UNCC 6 Mans | Top 5",
+                desc=Leaderboard.showLeaderboard(limit=5) + viewFullLb
+            )
+            edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
+            return edited_embed
+        else:
+            embed = ErrorEmbed(
+                title="No Leaderboard!",
+                desc="There are currently no leaderboard statistics!"
+            )
+            edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
+            return edited_embed
 
     else:
         embed = ErrorEmbed(

--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -396,11 +396,19 @@ def leaderboard(author: Member, mentions: str, lbChannelId: int, *arg) -> Embed:
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed
 
-    elif (len(arg) == 0 and playerMentioned == False):
+    elif (len(arg) == 0 and playerMentioned == False and not Leaderboard.checkLeaderboard()):
         viewFullLb = "\nTo see the full leaderboard, visit <#{0}>.".format(lbChannelId) if (lbChannelId != -1) else ""
         embed = InfoEmbed(
             title="UNCC 6 Mans | Top 5",
             desc=Leaderboard.showLeaderboard(limit=5) + viewFullLb
+        )
+        edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
+        return edited_embed
+
+    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.checkLeaderboard()):
+        embed = ErrorEmbed(
+            title="No Leaderboard!",
+            desc="There are currently no leaderboard statistics!"
         )
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed

--- a/src/Commands/SixMans.py
+++ b/src/Commands/SixMans.py
@@ -396,7 +396,7 @@ def leaderboard(author: Member, mentions: str, lbChannelId: int, *arg) -> Embed:
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed
 
-    elif (len(arg) == 0 and playerMentioned == False and not Leaderboard.checkLeaderboard()):
+    elif (len(arg) == 0 and playerMentioned == False and not Leaderboard.emptyLeaderboard()):
         viewFullLb = "\nTo see the full leaderboard, visit <#{0}>.".format(lbChannelId) if (lbChannelId != -1) else ""
         embed = InfoEmbed(
             title="UNCC 6 Mans | Top 5",
@@ -405,7 +405,7 @@ def leaderboard(author: Member, mentions: str, lbChannelId: int, *arg) -> Embed:
         edited_embed = CaptainsRandomHelpEmbed(embed, blueTeam, orangeTeam, blueCap, orangeCap)
         return edited_embed
 
-    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.checkLeaderboard()):
+    elif (len(arg) == 0 and playerMentioned == False and Leaderboard.emptyLeaderboard()):
         embed = ErrorEmbed(
             title="No Leaderboard!",
             desc="There are currently no leaderboard statistics!"

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -188,7 +188,7 @@ def showLeaderboard(player: str = None, limit: int = None) -> str or List[str]:
         return msgs if len(msgs) > 1 else msgs[0]
 
 
-def checkLeaderboard() -> bool:
+def emptyLeaderboard() -> bool:
     if (len(leaderboard) < 6):
         return True
 

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -188,6 +188,11 @@ def showLeaderboard(player: str = None, limit: int = None) -> str or List[str]:
         return msgs if len(msgs) > 1 else msgs[0]
 
 
+def checkLeaderboard() -> bool:
+    if (len(leaderboard) < 6):
+        return True
+
+
 def resetFromRemote(remoteData: dict) -> None:
     leaderboard.truncate()
     for p in remoteData:

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -1,6 +1,6 @@
 import AWSHelper as AWS
 from DataFiles import leaderboard, activeMatches
-from Types import BallChaser, Team, MatchKey, LbKey
+from Types import BallChaser, BallChaserKey, Team, MatchKey, LbKey
 from discord import Member
 from json import dumps
 from tinydb import where
@@ -188,9 +188,8 @@ def showLeaderboard(player: str = None, limit: int = None) -> str or List[str]:
         return msgs if len(msgs) > 1 else msgs[0]
 
 
-def emptyLeaderboard() -> bool:
-    if (len(leaderboard) < 6):
-        return True
+def countLeaderboard() -> int:
+    return leaderboard.count(where(BallChaserKey.ID).exists())
 
 
 def resetFromRemote(remoteData: dict) -> None:

--- a/src/Queue.py
+++ b/src/Queue.py
@@ -43,20 +43,22 @@ def clearQueue() -> None:
 
 def validateOrangePick(player: Member) -> bool:
     player = currQueue.get(doc_id=player.id)
-    return (
-        currQueue.count(where(BallChaserKey.TEAM) == Team.BLUE) == 2 and
-        player[BallChaserKey.IS_CAP] and
-        player[BallChaserKey.TEAM] == Team.ORANGE
-    )
+    if (player is not None):
+        return (
+            currQueue.count(where(BallChaserKey.TEAM) == Team.BLUE) == 2 and
+            player[BallChaserKey.IS_CAP] and
+            player[BallChaserKey.TEAM] == Team.ORANGE
+        )
 
 
 def validateBluePick(player: Member) -> bool:
     player = currQueue.get(doc_id=player.id)
-    return (
-        currQueue.count(where(BallChaserKey.TEAM) == Team.BLUE) == 1 and
-        player[BallChaserKey.IS_CAP] and
-        player[BallChaserKey.TEAM] == Team.BLUE
-    )
+    if (player is not None):
+        return (
+            currQueue.count(where(BallChaserKey.TEAM) == Team.BLUE) == 1 and
+            player[BallChaserKey.IS_CAP] and
+            player[BallChaserKey.TEAM] == Team.BLUE
+        )
 
 
 def getTeamList() -> Tuple[List[BallChaser], List[BallChaser]]:


### PR DESCRIPTION
The player validation while picking a player for a team is a bug that was introduced with Norm v7. This fix checks if the player is not a NoneType.
The leaderboard top 5 not working when there aren't any leaderboard stats has been fixed by checking if the leaderboard stats length is less than 6.