### PR TITLE
Admin force report

### DIFF
--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -159,9 +159,9 @@ async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg
 
         if (len(arg) > 0 and "<@!" in arg[0]):
             split = mentions.split("<@!")
-            if (len(arg) == 2 and str(arg[1]).lower() == Team.BLUE):
+            if (str(arg[1]).lower() == Team.BLUE):
                 player_id = split[1][:-6]
-            elif(len(arg) == 2 and str(arg[1]).lower() == Team.ORANGE):
+            elif(str(arg[1]).lower() == Team.ORANGE):
                 player_id = split[1][:-8]
             else:
                 return ErrorEmbed(
@@ -179,10 +179,10 @@ async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg
                     except Exception as e:
                         print("! Norm does not have access to update the leaderboard.", e)
 
-                return AdminEmbed(
-                    title="Match Force Reported Successfully",
-                    desc="You may now re-queue."
-                )
+                    return AdminEmbed(
+                        title="Match Force Reported Successfully",
+                        desc="You may now re-queue."
+                    )
             else:
                 return ErrorEmbed(
                     title="Did Not Mention a Player",

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -172,14 +172,7 @@ async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg
             if (player_id.isdigit()):
                 msg = reportMatch(player_id, arg[1], True)
 
-                if (":x:" in msg):
-                    return ErrorEmbed(
-                        title="Match Not Found",
-                        desc=msg[4:]
-                    )
-
-                if (":white_check_mark:" in msg):
-
+                if (msg):
                     try:
                         # if match was reported successfully, update leaderboard channel
                         await updateLeaderboardChannel(lbChannel)

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -157,7 +157,7 @@ def brokenQueue(player: Member, roles: List[Role]) -> Embed:
 async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg) -> Embed:
     if (Queue.isBotAdmin(roles)):
 
-        if (len(arg) > 0 and "<@!" in arg[0]):
+        if (len(arg) == 2 and "<@!" in arg[0]):
             split = mentions.split("<@!")
             if (str(arg[1]).lower() == Team.BLUE):
                 player_id = split[1][:-6]

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -2,9 +2,12 @@ from CheckForUpdates import updateBot
 from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed, CaptainsRandomHelpEmbed
 from Leaderboard import brokenQueue as lbBrokenQueue
 from typing import List
+from Types import Team
 from bot import __version__
-from discord import Role, Embed, Member
+from discord import Role, Embed, Member, channel as Channel
 import Queue
+from Commands.Utils import updateLeaderboardChannel
+from Leaderboard import reportMatch
 
 
 def update(roles: List[Role]) -> Embed:
@@ -149,6 +152,49 @@ def brokenQueue(player: Member, roles: List[Role]) -> Embed:
         title="Could Not Remove Queue",
         desc=msg
     )
+
+
+async def forceReport(mentions: List[Member], roles: List[Role], lbChannel: Channel, *arg) -> Embed:
+    if (Queue.isBotAdmin(roles)):
+        if (len(mentions) == 1):
+            if (len(arg) == 2 and (str(arg[1]).lower() == Team.BLUE or str(arg[1]).lower() == Team.ORANGE)):
+
+                player = mentions[0]
+                msg = reportMatch(player, arg[1], True)
+
+                if (":x:" in msg):
+                    return ErrorEmbed(
+                        title="Match Not Found",
+                        desc=msg[4:]
+                    )
+
+                if (":white_check_mark:" in msg):
+
+                    try:
+                        # if match was reported successfully, update leaderboard channel
+                        await updateLeaderboardChannel(lbChannel)
+                    except Exception as e:
+                        print("! Norm does not have access to update the leaderboard.", e)
+
+                return AdminEmbed(
+                    title="Match Force Reported Successfully",
+                    desc="You may now re-queue."
+                )
+            else:
+                return ErrorEmbed(
+                    title="You Must Report A Valid Team",
+                    desc="You did not supply a valid team to report."
+                )
+        else:
+            return ErrorEmbed(
+                title="Could Not Report The Match",
+                desc="You must mention one player who is in the match you want to report."
+            )
+    else:
+        return ErrorEmbed(
+            title="Permission Denied",
+            desc="You do not have the strength to force report matches. Ask an admin if you need to force report a match." # noqa
+        )
 
 
 # Disabling command as it does not work with the new executable.

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -154,13 +154,23 @@ def brokenQueue(player: Member, roles: List[Role]) -> Embed:
     )
 
 
-async def forceReport(mentions: List[Member], roles: List[Role], lbChannel: Channel, *arg) -> Embed:
+async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg) -> Embed:
     if (Queue.isBotAdmin(roles)):
-        if (len(mentions) == 1):
-            if (len(arg) == 2 and (str(arg[1]).lower() == Team.BLUE or str(arg[1]).lower() == Team.ORANGE)):
 
-                player = mentions[0]
-                msg = reportMatch(player, arg[1], True)
+        if (len(arg) > 0 and "<@!" in arg[0]):
+            split = mentions.split("<@!")
+            if (len(arg) == 2 and str(arg[1]).lower() == Team.BLUE):
+                player_id = split[1][:-6]
+            elif(len(arg) == 2 and str(arg[1]).lower() == Team.ORANGE):
+                player_id = split[1][:-8]
+            else:
+                return ErrorEmbed(
+                    title="You Must Report A Valid Team",
+                    desc="You did not supply a valid team to report."
+                )
+
+            if (player_id.isdigit()):
+                msg = reportMatch(player_id, arg[1], True)
 
                 if (":x:" in msg):
                     return ErrorEmbed(
@@ -182,12 +192,12 @@ async def forceReport(mentions: List[Member], roles: List[Role], lbChannel: Chan
                 )
             else:
                 return ErrorEmbed(
-                    title="You Must Report A Valid Team",
-                    desc="You did not supply a valid team to report."
+                    title="Did Not Mention a Player",
+                    desc="You must mention one player who is in the match you want to report."
                 )
         else:
-            return ErrorEmbed(
-                title="Could Not Report The Match",
+            ErrorEmbed(
+                title="Did Not Mention a Player",
                 desc="You must mention one player who is in the match you want to report."
             )
     else:

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -5,7 +5,7 @@ from discord import Member
 from json import dumps
 from tinydb import where
 from tinydb.table import Document
-from typing import List
+from typing import List, Union
 import concurrent.futures
 
 
@@ -39,8 +39,11 @@ def brokenQueue(player: Member) -> str:
     return ":white_check_mark: Previous queue removed."
 
 
-def getActiveMatch(player: Member) -> Document or None:
-    return activeMatches.get(where(str(player.id)).exists())
+def getActiveMatch(player: Union[Member, str]) -> Document or None:
+    if (isinstance(player, Member)):
+        return activeMatches.get(where(str(player.id)).exists())
+    elif (isinstance(player, str)):
+        return activeMatches.get(where(player).exists())
 
 
 def getBallChaser(player: int) -> BallChaser:
@@ -71,14 +74,18 @@ def reportConfirm(player: BallChaser, match: Document, whoWon: Team) -> bool:
     return True
 
 
-def reportMatch(player: Member, whoWon: Team) -> bool:
+def reportMatch(player: Union[Member, str], whoWon: Team, adminOverride=False) -> str:
     global sorted_lb
     match = getActiveMatch(player)
 
     if (not match):
         return False
 
-    foundPlayer = match[str(player.id)]
+    if (isinstance(player, Member)):
+        foundPlayer = match[str(player.id)]
+    elif (isinstance(player, str)):
+        foundPlayer = match[player]
+
     player = BallChaser(
         name=foundPlayer[MatchKey.NAME],
         id=foundPlayer[MatchKey.ID],
@@ -88,43 +95,44 @@ def reportMatch(player: Member, whoWon: Team) -> bool:
     if (not report_confirm_success):
         return report_confirm_success
 
-    for key in match:
-        if (key != MatchKey.REPORTED_WINNER):
-            teamMember = match[key]
-            if (
-                (whoWon == Team.BLUE and teamMember["team"] == Team.BLUE) or
-                (whoWon == Team.ORANGE and teamMember["team"] == Team.ORANGE)
-            ):
-                win = 1
-                loss = 0
-            else:
-                win = 0
-                loss = 1
+    if (report_confirm_success or adminOverride == True):
+        for key in match:
+            if (key != MatchKey.REPORTED_WINNER):
+                teamMember = match[key]
+                if (
+                    (whoWon == Team.BLUE and teamMember["team"] == Team.BLUE) or
+                    (whoWon == Team.ORANGE and teamMember["team"] == Team.ORANGE)
+                ):
+                    win = 1
+                    loss = 0
+                else:
+                    win = 0
+                    loss = 1
 
-            player = leaderboard.get(doc_id=teamMember[MatchKey.ID])
-            if (not player):
-                leaderboard.insert(Document({
-                    LbKey.ID: teamMember[MatchKey.ID],
-                    LbKey.NAME: teamMember[MatchKey.NAME],
-                    LbKey.WINS: win,
-                    LbKey.LOSSES: loss,
-                    LbKey.MATCHES: 1,
-                    LbKey.WIN_PERC: float(win),
-                }, doc_id=teamMember[MatchKey.ID]))
-            else:
-                updated_player = {
-                    LbKey.NAME: teamMember[MatchKey.NAME],
-                    LbKey.WINS: player[LbKey.WINS] + win,
-                    LbKey.LOSSES: player[LbKey.LOSSES] + loss,
-                    LbKey.MATCHES: player[LbKey.MATCHES] + 1,
-                    LbKey.WIN_PERC: player[LbKey.WIN_PERC],
-                }
+                player = leaderboard.get(doc_id=teamMember[MatchKey.ID])
+                if (not player):
+                    leaderboard.insert(Document({
+                        LbKey.ID: teamMember[MatchKey.ID],
+                        LbKey.NAME: teamMember[MatchKey.NAME],
+                        LbKey.WINS: win,
+                        LbKey.LOSSES: loss,
+                        LbKey.MATCHES: 1,
+                        LbKey.WIN_PERC: float(win),
+                    }, doc_id=teamMember[MatchKey.ID]))
+                else:
+                    updated_player = {
+                        LbKey.NAME: teamMember[MatchKey.NAME],
+                        LbKey.WINS: player[LbKey.WINS] + win,
+                        LbKey.LOSSES: player[LbKey.LOSSES] + loss,
+                        LbKey.MATCHES: player[LbKey.MATCHES] + 1,
+                        LbKey.WIN_PERC: player[LbKey.WIN_PERC],
+                    }
 
-                total_wins = int(updated_player[LbKey.WINS])
-                total_matches = int(updated_player[LbKey.MATCHES])
-                updated_player[LbKey.WIN_PERC] = float("{:.2f}".format(total_wins / total_matches))
+                    total_wins = int(updated_player[LbKey.WINS])
+                    total_matches = int(updated_player[LbKey.MATCHES])
+                    updated_player[LbKey.WIN_PERC] = float("{:.2f}".format(total_wins / total_matches))
 
-                leaderboard.update(updated_player, doc_ids=[player.doc_id])
+                    leaderboard.update(updated_player, doc_ids=[player.doc_id])
 
     activeMatches.remove(doc_ids=[match.doc_id])
     sorted_lb = sorted(leaderboard.all(), key=lambda x: (x[LbKey.WINS], x[LbKey.WIN_PERC]), reverse=True)

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -74,7 +74,7 @@ def reportConfirm(player: BallChaser, match: Document, whoWon: Team) -> bool:
     return True
 
 
-def reportMatch(player: Union[Member, str], whoWon: Team, adminOverride=False) -> str:
+def reportMatch(player: Union[Member, str], whoWon: Team, adminOverride: bool = False) -> bool:
     global sorted_lb
     match = getActiveMatch(player)
 
@@ -92,8 +92,6 @@ def reportMatch(player: Union[Member, str], whoWon: Team, adminOverride=False) -
         team=foundPlayer[MatchKey.TEAM]
     )
     report_confirm_success = reportConfirm(player, match, whoWon)
-    if (not report_confirm_success):
-        return report_confirm_success
 
     if (report_confirm_success or adminOverride == True):
         for key in match:
@@ -133,6 +131,9 @@ def reportMatch(player: Union[Member, str], whoWon: Team, adminOverride=False) -
                     updated_player[LbKey.WIN_PERC] = float("{:.2f}".format(total_wins / total_matches))
 
                     leaderboard.update(updated_player, doc_ids=[player.doc_id])
+
+    elif (not report_confirm_success):
+        return report_confirm_success
 
     activeMatches.remove(doc_ids=[match.doc_id])
     sorted_lb = sorted(leaderboard.all(), key=lambda x: (x[LbKey.WINS], x[LbKey.WIN_PERC]), reverse=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -79,6 +79,9 @@ valid_commands = [
     "rank",
     "rankings",
     "stonks",
+    "forceReport",
+    "fr",
+    "force"
 ]
 
 
@@ -354,6 +357,11 @@ async def showLeaderboard(ctx, *arg):
 @client.command(name="brokenq", aliases=["requeue", "re-q"], pass_context=True)
 async def removeLastPoppedQueue(ctx):
     await sendMessage(ctx, Admin.brokenQueue(ctx.message.author, ctx.message.author.roles), "queue")
+
+
+@client.command(name="forceReport", aliases=["fr", "force"], pass_context=True)
+async def forceReport(ctx, *arg):
+    await ctx.send(embed=await Admin.forceReport(ctx.message.content, ctx.message.author.roles, LB_CHANNEL, *arg))
 
 
 @client.command(name="clear", aliases=["clr", "reset"], pass_context=True)


### PR DESCRIPTION
In order to work around the problem that individuals are not allowed to re-queue if one team does not report the match. Admins should be able to override the report and force the match to be reported. This change offers the ability for admins to force a match to be reported by mentioning a player and the team that won.