### PR TITLE
Admin broken queue when not in queue

### DIFF
--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -177,6 +177,10 @@ async def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
                     title="Could Not Remove Queue",
                     desc=msg
                 )
+        return ErrorEmbed(
+            title="Did Not Mention a Player",
+            desc="Please mention a player in an active match to broken queue."
+        )
     return ErrorEmbed(
         title="Permission Denied",
         desc="You do not have the leg strength to kick other players."

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -1,6 +1,6 @@
 from CheckForUpdates import updateBot
 from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed, CaptainsRandomHelpEmbed
-from Leaderboard import brokenQueue as lbBrokenQueue
+from Leaderboard import brokenQueue as lbBrokenQueue, getBallChaser
 from typing import List
 from Types import Team
 from bot import __version__
@@ -153,6 +153,31 @@ def brokenQueue(player: Member, roles: List[Role]) -> Embed:
         title="Could Not Remove Queue",
         desc=msg
     )
+
+
+def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
+    if (Queue.isBotAdmin(roles)):
+
+        if (len(arg) > 0 and "<@!" in arg[0]):
+            split = mentions.split("<@!")
+            player_id = split[1][:-1]
+
+            if (player_id.isdigit()):
+                member = getBallChaser(player_id)
+                msg = lbBrokenQueue(member)
+                if (":white_check_mark:" in msg):
+                    return QueueUpdateEmbed(
+                        title="Popped Queue Removed",
+                        desc="The popped queue has been removed from active matches. You may now re-queue."
+                    ).add_field(
+                        name="Current Queue 0/6",
+                        value="Queue is empty."
+                    )
+
+                return ErrorEmbed(
+                    title="Could Not Remove Queue",
+                    desc=msg
+                )
 
 
 async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg) -> Embed:

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -1,6 +1,6 @@
 from CheckForUpdates import updateBot
 from EmbedHelper import AdminEmbed, ErrorEmbed, QueueUpdateEmbed, CaptainsRandomHelpEmbed
-from Leaderboard import brokenQueue as lbBrokenQueue, getBallChaser
+from Leaderboard import brokenQueue as lbBrokenQueue
 from typing import List
 from Types import Team
 from bot import __version__
@@ -155,7 +155,7 @@ def brokenQueue(player: Member, roles: List[Role]) -> Embed:
     )
 
 
-def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
+async def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
     if (Queue.isBotAdmin(roles)):
 
         if (len(arg) > 0 and "<@!" in arg[0]):
@@ -163,8 +163,7 @@ def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
             player_id = split[1][:-1]
 
             if (player_id.isdigit()):
-                member = getBallChaser(player_id)
-                msg = lbBrokenQueue(member)
+                msg = lbBrokenQueue(player_id)
                 if (":white_check_mark:" in msg):
                     return QueueUpdateEmbed(
                         title="Popped Queue Removed",
@@ -178,6 +177,10 @@ def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
                     title="Could Not Remove Queue",
                     desc=msg
                 )
+    return ErrorEmbed(
+        title="Permission Denied",
+        desc="You do not have the leg strength to kick other players."
+    )
 
 
 async def forceReport(mentions: str, roles: List[Role], lbChannel: Channel, *arg) -> Embed:

--- a/src/Commands/Admin.py
+++ b/src/Commands/Admin.py
@@ -183,7 +183,7 @@ async def mentionBrokenQueue(mentions: str, roles: List[Role], *arg) -> Embed:
         )
     return ErrorEmbed(
         title="Permission Denied",
-        desc="You do not have the leg strength to kick other players."
+        desc="You do not have permission to break the queue without a majority."
     )
 
 

--- a/src/Leaderboard.py
+++ b/src/Leaderboard.py
@@ -24,7 +24,7 @@ def startMatch(blueTeam: List[BallChaser], orangeTeam: List[BallChaser]) -> None
     activeMatches.insert(newActiveMatch)
 
 
-def brokenQueue(player: Member) -> str:
+def brokenQueue(player: Union[Member, str]) -> str:
     if (activeMatches.count(where(MatchKey.REPORTED_WINNER).exists()) == 0):
         return "There are no currently active matches."
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -366,7 +366,7 @@ async def removeLastPoppedQueue(ctx):
 
 
 @client.command(name="bq", aliases=["mentionBrokenQueue"], pass_context=True)
-async def mentionBQ(ctx, *arg):
+async def mentionBq(ctx, *arg):
     await ctx.send(embed=await Admin.mentionBrokenQueue(ctx.message.content, ctx.message.author.roles, *arg))
 
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -85,7 +85,9 @@ valid_commands = [
     "mmrMultiplier",
     "mmr",
     "multiplier",
-    "multiply"
+    "multiply",
+    "bq",
+    "mentionBrokenQueue"
 ]
 
 
@@ -361,6 +363,11 @@ async def showLeaderboard(ctx, *arg):
 @client.command(name="brokenq", aliases=["requeue", "re-q"], pass_context=True)
 async def removeLastPoppedQueue(ctx):
     await sendMessage(ctx, Admin.brokenQueue(ctx.message.author, ctx.message.author.roles), "queue")
+
+
+@client.command(name="bq", aliases=["mentionBrokenQueue"], pass_context=True)
+async def mentionBQ(ctx, *arg):
+    await ctx.send(embed=await Admin.mentionBrokenQueue(ctx.message.content, ctx.message.author.roles, *arg))
 
 
 @client.command(name="forceReport", aliases=["fr", "force"], pass_context=True)

--- a/src/bot.py
+++ b/src/bot.py
@@ -2,7 +2,7 @@ __author__ = "Caleb Smith / Twan / Matt Wells (Tux) / Austin Baker (h)"
 __copyright__ = "Copyright 2019, MIT License"
 __credits__ = "Caleb Smith / Twan / Matt Wells (Tux) / Austin Baker (h)"
 __license__ = "MIT"
-__version__ = "7.1.0"
+__version__ = "7.1.1"
 __maintainer__ = "Caleb Smith / Twan / Matt Wells (Tux) / Austin Baker (h)"
 __email__ = "caleb.benjamin9799@gmail.com / unavailable / mattwells878@gmail.com / noise.9no@gmail.com"
 


### PR DESCRIPTION
This is a bug fix for Admins not being able to brokenqueue active matches that they were not in.
This bug fix introduces the ability for admins to be able to broken queue any match by using `!bq @<player>`